### PR TITLE
Remove start of mysql when used as client

### DIFF
--- a/How-To/setup-iam-access-to-rds/README.MD
+++ b/How-To/setup-iam-access-to-rds/README.MD
@@ -21,8 +21,6 @@ Follow this article in **[Youtube](https://youtu.be/tvXZWhu35PY)**
 Install the following packages and commands
 ```sh
 yum install curl mysql -y
-service mysqld start
-chkconfig mysqld on
 ```
 
 ### Setup Database to use IAM


### PR DESCRIPTION
In the demo of IAM Database Authentication for Mysql, the mysql
installed in the box to connect to RDS does not need to be running
since it is only used as a client. Removing the lines which are
not needed from the docs
